### PR TITLE
Update Minecraft Wiki links to new domain

### DIFF
--- a/structure-editor/index.html
+++ b/structure-editor/index.html
@@ -596,7 +596,7 @@
         </div>
         <div class="app-inner app-tab-content group-item" id="item-potion">
           <label><input type="checkbox" checked id="item-potion-wasjustbrewed"> Was just brewed?</label><br>
-          Looking for the potion color/effect/strength? Bedrock potion effects are stored in data values (available in the Overview tab), not NBT data. <a href="https://minecraft.fandom.com/wiki/Potion#Metadata" target="_blank">Here</a>'s a list of applicable values.
+          Looking for the potion color/effect/strength? Bedrock potion effects are stored in data values (available in the Overview tab), not NBT data. <a href="https://minecraft.wiki/w/Potion#Metadata" target="_blank">Here</a>'s a list of applicable values.
         </div>
         <div class="app-inner app-tab-content group-item" id="item-crossbow">
           Charged Item:<br>
@@ -926,7 +926,7 @@
         </div>
         <div class="app-inner app-tab-content group-tentity" id="tentity-banner">
           <label><input type="checkbox" id="tentity-banner-type"> Is ominous?</label><br>
-          <label>Base Color: <input type="number" class="app-input" placeholder="15" id="tentity-banner-base"></label> <a href="https://minecraft.fandom.com/wiki/Banner#Item" target="_blank" style="font-size: 8pt;">Values</a><br><br>
+          <label>Base Color: <input type="number" class="app-input" placeholder="15" id="tentity-banner-base"></label> <a href="https://minecraft.wiki/w/Banner#Item" target="_blank" style="font-size: 8pt;">Values</a><br><br>
           If you would like to see a pattern editor, suggest it over on our Discord server.
         </div>
         <div class="app-inner app-tab-content group-tentity" id="tentity-beehive">

--- a/tellraw-generator/index.html
+++ b/tellraw-generator/index.html
@@ -169,7 +169,7 @@
         <div class="button-editor-delete-button" id="translate-delete" onclick="deleteTranslation()"><img src="https://cdn.glitch.com/17ff8eee-9239-4ba0-8a5c-9263261550b5%2Ficon_trash.png" style="height: 32px;image-rendering: pixelated;"></div>
           <h2 style="text-align:center;user-select:none;" class="lefttitle">Translation Editor</h2>
           Translation key: <input class="app-input" type="text" placeholder="commands.op.success" style="width: 100%;" id="translateKey" oninput="updateTranslation()"><br>
-        With: <span style="font-size: 7pt;"><a href="https://minecraft.fandom.com/wiki/Raw_JSON_text_format#With" style="background-color:rgba(255,255,255,0.3);padding:3px;border-radius:5px;color:#82f782;" target="_blank">What's this?</a></span><br><textarea style="width: 100%;" rows="8" placeholder="{'rawtext': [{'text': ''}]}" id="translateText" oninput="updateTranslation()"></textarea>
+        With: <span style="font-size: 7pt;"><a href="https://minecraft.wiki/w/Raw_JSON_text_format#With" style="background-color:rgba(255,255,255,0.3);padding:3px;border-radius:5px;color:#82f782;" target="_blank">What's this?</a></span><br><textarea style="width: 100%;" rows="8" placeholder="{'rawtext': [{'text': ''}]}" id="translateText" oninput="updateTranslation()"></textarea>
       </div>
     </div>
     


### PR DESCRIPTION
The Minecraft Fandom wiki has been forked to a new domain: minecraft.wiki. Learn more here: https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom. This PR updates all URLs accordingly.